### PR TITLE
ci: add PR-gate workflow running pytest on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Lint and Test
+
+on:
+  pull_request:
+    branches: [main, "feat/**", "fix/**"]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.6.14"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Create test env
+        run: cp tests/sample.env tests/.env
+
+      - name: Tests (pytest)
+        run: uv run pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       - name: Create test env
         run: cp tests/sample.env tests/.env


### PR DESCRIPTION
## Summary

Stacked on top of #15. Adds a CI workflow that runs `pytest tests/` on every PR and push to `main`, across Python 3.11 and 3.12.

Existing `main.yml` only fires on `workflow_dispatch` (the release path), so unit tests never ran on PRs — the 167-test suite landed via #15 was only validated locally.

## Why a new workflow rather than extending `main.yml`?

`main.yml` is the release pipeline: bumps version, tags, publishes to PyPI. Adding PR triggers there would entangle gate behaviour with release behaviour. Separate file keeps each one auditable in isolation.

## Lint deliberately deferred

`uv run ruff check src/` currently reports 10 pre-existing E501 violations on `main`. Turning lint on here would make this PR fail before it could merge. Cleaning those up + flipping lint on is a follow-up PR (small footprint, line-wraps only).

## Test plan

- [ ] PR opens → `Lint and Test / lint-and-test (3.11)` and `(3.12)` show up as required checks
- [ ] Both run `uv run pytest tests/` and report green (167 passed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)