### PR TITLE
UN-3479 [FIX] release workflow: install --all-extras to match PR gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,10 @@ jobs:
           version: "0.6.14"
           enable-cache: true
 
-      # Install dependencies
+      # Install dependencies (must match test.yml so the release-run lint/test
+      # config matches the PR-gate; --all-extras pulls in the clone CLI deps).
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       # Compute and stage the new version locally — defer commit/tag/release
       # until lint+tests+build+publish all pass, so any failure leaves main untouched.


### PR DESCRIPTION
## Summary

Follow-up to #17. The release-workflow dispatch on `main` ([run 26506941508](https://github.com/Zipstack/unstract-python-client/actions/runs/26506941508/job/78061653671)) failed at pytest collection:

```
tests/clone/test_cli.py:12: in <module>
    from click.testing import CliRunner
E   ModuleNotFoundError: No module named 'click'
```

Root cause: `main.yml` installs `uv sync --dev` but `test.yml` (PR gate, after #16) installs `uv sync --dev --all-extras`. The `clone` extra carries `click` + `rich`, needed for `tests/clone/test_cli.py`. So PR CI passed while the release dispatch failed — same code, different env.

Fix: align `main.yml`'s install step with `test.yml`. Both now run `uv sync --dev --all-extras`.

## Test plan
- [ ] CI on this PR — `lint-and-test (3.11)` and `lint-and-test (3.12)` continue green
- [ ] After merge: manual `main.yml` dispatch with `minor` bump → expect clean `v1.3.0` release end-to-end (lint + test + build + publish + commit/tag/release all succeed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)