### PR TITLE
UN-3770 [CI] Add focused clone test workflow

### DIFF
--- a/.github/workflows/clone-tests.yml
+++ b/.github/workflows/clone-tests.yml
@@ -1,0 +1,52 @@
+name: Clone Tests
+
+# Focused, fast signal for the clone tooling — runs only the clone suite when
+# clone code, its tests, or the dependency set changes. The full suite in
+# test.yml still runs on every PR; this gates the pagination page-following
+# logic (client._paginate) that silently truncates a migration if it regresses.
+on:
+  pull_request:
+    branches: [main, "feat/**", "fix/**"]
+    paths:
+      - "src/unstract/clone/**"
+      - "tests/clone/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/clone-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/unstract/clone/**"
+      - "tests/clone/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/clone-tests.yml"
+
+jobs:
+  clone-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.6.14"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev --all-extras
+
+      - name: Create test env
+        run: cp tests/sample.env tests/.env
+
+      - name: Clone tests (pytest)
+        run: uv run pytest tests/clone/ -v


### PR DESCRIPTION
## What & why

Stacked on #24 (`feat/paginate-list-helpers`). Adds a **paths-scoped** GitHub Actions workflow (`.github/workflows/clone-tests.yml`) that runs the clone test suite whenever clone code, its tests, or the dependency set changes.

The user wants automated test runs on **every** change to the clone code. The existing `test.yml` already runs the full suite on every PR, but this adds a dedicated, fast, clearly-named signal narrowed to `tests/clone/` — so a regression in the pagination page-following logic (`client._paginate`) is obvious. Silent partial-data truncation during a clone is a worse failure mode than a hard break, so that path stays guarded on every clone change.

## Trigger paths

- `src/unstract/clone/**` (clone script + `client.py`, which holds `_paginate` and all 23 list helpers)
- `tests/clone/**`
- `pyproject.toml`, `uv.lock`
- the workflow file itself

## Conventions

Matches `test.yml`: Python 3.11/3.12 matrix, `uv` 0.6.14, `uv sync --dev --all-extras`, `cp tests/sample.env tests/.env`.

## Testing

Full clone suite green locally: **197 passed** (`tests/clone/`), including the 3 new `_paginate` tests from #24 (follows `next` across pages, raises on short read, raises on cyclic `next`) plus the pre-existing bare-list and single-page-envelope tests.

Base is set to `#24`'s branch so the diff shows only the CI addition; retarget to `main` if #24 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)