### PR TITLE
chore: bump version to 1.5.3

### DIFF
--- a/src/unstract/api_deployments/__init__.py
+++ b/src/unstract/api_deployments/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 
 from .client import APIDeploymentsClient as APIDeploymentsClient
 


### PR DESCRIPTION
Patch bump `1.5.2` → `1.5.3` to cut a release for #24 (UN-3770 step 1).

#24 fixed a live bug where every `list_*` clone helper read only page one of a DRF-paginated response and silently truncated. That change is merged but unreleased; the downstream OSS work (step 2, flipping list endpoints to unconditional pagination) needs a released client with the fix.

- Bugfix, no new public API, no breaking change → **patch**.
- Version source: `src/unstract/api_deployments/__init__.py` (hatch dynamic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)